### PR TITLE
Fixed typo in cave-emu.cfg

### DIFF
--- a/system/cave-emu.cfg
+++ b/system/cave-emu.cfg
@@ -1,5 +1,5 @@
 // A 4-sided cave example
-// This example creates separate windows for a 4-sided cave (laft, right, front, back), plus a separate operator window.
+// This example creates separate windows for a 4-sided cave (left, right, front, back), plus a separate operator window.
 // The operator window accepts keyboard and mouve input to control the application.
 config:
 {


### PR DESCRIPTION
Fixed typo of "laft" to "left."