### PR TITLE
Compile warning fixes.

### DIFF
--- a/src/omega/Camera.cpp
+++ b/src/omega/Camera.cpp
@@ -1,39 +1,39 @@
 /******************************************************************************
  * THE OMEGA LIB PROJECT
  *-----------------------------------------------------------------------------
- * Copyright 2010-2015		Electronic Visualization Laboratory, 
+ * Copyright 2010-2015		Electronic Visualization Laboratory,
  *							University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-----------------------------------------------------------------------------
- * Copyright (c) 2010-2015, Electronic Visualization Laboratory,  
+ * Copyright (c) 2010-2015, Electronic Visualization Laboratory,
  * University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without 
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
- * form must reproduce the above copyright notice, this list of conditions and 
- * the following disclaimer in the documentation and/or other materials 
- * provided with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE  GOODS OR  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY,  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE  OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE  GOODS OR  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY,  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE  OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * What's in this file
- *	The Camera class: handles information about a view transformation, head 
+ *	The Camera class: handles information about a view transformation, head
  *	tracking and optional target buffers for off screen rendering
- *	A camera can have a controller that is used to implement a navigation 
+ *	A camera can have a controller that is used to implement a navigation
  *	technique.
  ******************************************************************************/
 #include "omega/RenderTarget.h"
@@ -70,7 +70,7 @@ Camera::Camera(Engine* e, uint flags):
     myViewPosition(0, 0),
     myViewSize(1, 1),
     myEnabled(true),
-    myClearColor(true), 
+    myClearColor(true),
     myClearDepth(true),
     myBackgroundColor(Color(0.1f,0.1f, 0.15f, 1)),
     myCanvasOrientation(Quaternion::Identity()),
@@ -88,7 +88,7 @@ Camera::Camera(Engine* e, uint flags):
 void Camera::setup(Setting& s)
 {
     //set position of camera
-    Vector3f camPos = Config::getVector3fValue("position", s, getPosition()); 
+    Vector3f camPos = Config::getVector3fValue("position", s, getPosition());
     setPosition(camPos);
 
     //set orientation of camera
@@ -98,10 +98,10 @@ void Camera::setup(Setting& s)
     // value in the Config::getVector3fValue.
     if(s.exists("orientation"))
     {
-        Vector3f camOri = Config::getVector3fValue("orientation", s); 
+        Vector3f camOri = Config::getVector3fValue("orientation", s);
         setPitchYawRoll(camOri * Math::DegToRad);
     }
-    
+
     myTrackerSourceId = Config::getIntValue("trackerSourceId", s, -1);
     if(myTrackerSourceId != -1) myTrackingEnabled = true;
 
@@ -123,7 +123,7 @@ void Camera::setup(Setting& s)
         if(controllerName == "gamepad") controller = new GamepadCameraController();
 
         setController(controller);
-        if(myController != NULL) 
+        if(myController != NULL)
         {
             myController->setup(s);
             setControllerEnabled(true);
@@ -147,16 +147,16 @@ void Camera::handleEvent(const Event& evt)
 {
     if(myTrackingEnabled)
     {
-        if(evt.getServiceType() == Event::ServiceTypeMocap &&
+        if(evt.getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypeMocap) &&
             ((myTrackerUserId != -1 && evt.getUserId() == myTrackerUserId) ||
                 evt.getSourceId() == myTrackerSourceId))
         {
-            // By convention (as of omicron 3.0), if this mocap event has int extra data, 
+            // By convention (as of omicron 3.0), if this mocap event has int extra data,
             // the first field is a joint id. This will not break with previous versions
             // of omicron, but no joint data will be read here.
             // NOTE: we need this check because multiple trackables may
             // share the same user id. We only want the head.
-            if(myTrackerUserId == -1 || (!evt.isExtraDataNull(0) && 
+            if(myTrackerUserId == -1 || (!evt.isExtraDataNull(0) &&
                 evt.getExtraDataType() == Event::ExtraDataIntArray &&
                 evt.getExtraDataInt(0) == Event::OMICRON_SKEL_HEAD))
             {
@@ -183,12 +183,12 @@ void Camera::updateTraversal(const UpdateContext& context)
     {
         // Update view transform.
         myViewTransform = Math::makeViewMatrix(
-            getDerivedPosition(), // + myHeadOffset, 
+            getDerivedPosition(), // + myHeadOffset,
             getDerivedOrientation());
 
         AffineTransform3 t = AffineTransform3::Identity();
     }
-    
+
     SceneNode::updateTraversal(context);
 }
 
@@ -253,7 +253,7 @@ bool Camera::overlapsTile(const DisplayTileConfig* tile)
     const Rect& cr = tile->displayConfig.getCanvasRect();
     Vector2f& vp = myViewPosition;
     Vector2f& vs = myViewSize;
-  
+
     // View rect contains the camera view rectangle in pixel coordinates.
     Rect viewRect((int)(vp[0] * cr.width()), (int)(vp[1] * cr.height()),
         (int)(vs[0] * cr.width()), (int)(vs[1] * cr.height()));
@@ -274,15 +274,15 @@ void Camera::beginDraw(DrawContext& context)
     }
 
     // updateViewport will set up the viewport for side-by-side stereo modes.
-    // Note that custom camera viewports and side-by-side stereo do not work 
+    // Note that custom camera viewports and side-by-side stereo do not work
     // together yet. If side-by-side stereo is enabled, it will override camera
     // viewport settings.
     context.updateViewport();
 
     context.setupInterleaver();
     context.updateTransforms(
-        myHeadTransform, myViewTransform, 
-        myEyeSeparation, 
+        myHeadTransform, myViewTransform,
+        myEyeSeparation,
         myNearZ, myFarZ);
 
     CameraOutput* output = myOutput[context.gpuContext->getId()];
@@ -360,7 +360,7 @@ void Camera::clear(DrawContext& context)
 
         // Update view bounds THEN update the viewport.
         // updateViewport will set up the viewport for side-by-side stereo modes.
-        // Note that custom camera viewports and side-by-side stereo do not work 
+        // Note that custom camera viewports and side-by-side stereo do not work
         // together yet. If side-by-side stereo is enabled, it will override camera
         // viewport settings.
         context.updateViewport();
@@ -421,14 +421,14 @@ Vector3f Camera::worldToLocalPosition(const Vector3f& position)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void Camera::setController(CameraController* value) 
-{ 
+void Camera::setController(CameraController* value)
+{
     if(myController != NULL)
     {
         ModuleServices::removeModule(myController);
     }
 
-    myController = value; 
+    myController = value;
     if(myController != NULL)
     {
         myController->setCamera(this);
@@ -442,7 +442,7 @@ void Camera::setCanvasTransform(const Vector3f& position, const Quaternion& orie
     myCanvasPosition = position;
     myCanvasOrientation = orientation;
     myCanvasScale = scale;
-    
+
     needUpdate();
 }
 
@@ -452,5 +452,3 @@ void Camera::updateFromParent(void) const
     SceneNode::updateFromParent();
     mDerivedOrientation = mDerivedOrientation * myCanvasOrientation;
 }
-
-

--- a/src/omega/ImageUtils.cpp
+++ b/src/omega/ImageUtils.cpp
@@ -2,26 +2,26 @@
  * THE OMEGA LIB PROJECT
  *-------------------------------------------------------------------------------------------------
  * Copyright 2010-2015		Electronic Visualization Laboratory, University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-------------------------------------------------------------------------------------------------
  * Copyright (c) 2010-2015, Electronic Visualization Laboratory, University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, are permitted 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this list of conditions 
- * and the following disclaimer. Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in the documentation and/or other 
- * materials provided with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF 
- * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *************************************************************************************************/
 #include "omega/ImageUtils.h"
@@ -74,7 +74,7 @@ public:
                     sImageQueueLock.unlock();
 
                     Ref<PixelData> res = ImageUtils::loadImage(task->getData().path, task->getData().isFullPath);
-                
+
                     if(!sShutdownLoaderThread)
                     {
                         task->getData().image = res;
@@ -124,8 +124,11 @@ int ImageUtils::getNumPreallocatedBlocks()
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void* ImageUtils::getPreallocatedBlock(int blockIndex)
 {
-    if(blockIndex < sPreallocBlocks.size()) return sPreallocBlocks[blockIndex];
-    return false;
+    if(blockIndex < sPreallocBlocks.size()) {
+        return sPreallocBlocks[blockIndex];
+    } else {
+        return NULL;
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -241,16 +244,16 @@ Ref<PixelData> ImageUtils::ffbmpToPixelData(FIBITMAP*& image, const String& file
     }
 
     if(sVerbose) ofmsg("Image loaded: %1%. Size: %2%x%3%", %filename %width %height);
-    
+
     byte* data = pixelData->map();
-    
+
     for(int i = 0; i < height; i++)
     {
         char* pixels = (char*)FreeImage_GetScanLine(image, i);
 		memcpy( data + i * width * pixelOffset, pixels, width * pixelOffset );
     }
     pixelData->unmap();
-    
+
     return pixelData;
 }
 
@@ -265,7 +268,7 @@ Ref<PixelData> ImageUtils::loadImage(const String& filename, bool hasFullPath)
             //ofmsg("LOOKUP: %1%%2%", %ogetdataprefix() %filename);
             if(!DataManager::findFile(ogetdataprefix() + filename, path))
             {
-                // Try adding the 
+                // Try adding the
                 ofwarn("ImageUtils::loadImage: could not load %1%: file not found.", %filename);
                 return NULL;
             }
@@ -294,7 +297,7 @@ Ref<PixelData> ImageUtils::loadImage(const String& filename, bool hasFullPath)
     // load files in big endian mode, while GIFs use little endian.
     // This causes gif file headers to be loaded incorrectly, generating
     // wrong width/height and crashing the universe.
-    // If we do not force big endian, on some platforms (like the OpenSUSE 
+    // If we do not force big endian, on some platforms (like the OpenSUSE
     // version used in CAVE2) freeimage will compile with the wrong endianness
     // and JPEGS will load with RGB channels inverted. There is probably a
     // workaround for all this, but disabling gif loading is a simple solution
@@ -353,7 +356,7 @@ Ref<PixelData> ImageUtils::decode(void* data, size_t size, const String& bufName
     int height = 0;
 
     FREE_IMAGE_FORMAT format = FreeImage_GetFileTypeFromMemory(mem);
-    
+
     FIBITMAP* image = FreeImage_LoadFromMemory(format, mem);
     if(image == NULL)
     {
@@ -362,7 +365,7 @@ Ref<PixelData> ImageUtils::decode(void* data, size_t size, const String& bufName
     }
 
     Ref<PixelData> pixelData = ffbmpToPixelData(image, bufName);
-    
+
     FreeImage_Unload(image);
     FreeImage_CloseMemory(mem);
 
@@ -430,7 +433,7 @@ ByteArray* ImageUtils::encode(PixelData* data, ImageFormat format)
             FIBITMAP* fibmp24 = FreeImage_ConvertTo24Bits(fibmp);
 
             // Swap needed for jpegs?
-            
+
 
             // Encode the bitmap to a freeimage memory buffer
             FreeImage_SaveToMemory(FIF_JPEG, fibmp24, fmem);

--- a/src/omega/TrackedObject.cpp
+++ b/src/omega/TrackedObject.cpp
@@ -1,32 +1,32 @@
 /******************************************************************************
  * THE OMEGA LIB PROJECT
  *-----------------------------------------------------------------------------
- * Copyright 2010-2015		Electronic Visualization Laboratory, 
+ * Copyright 2010-2015		Electronic Visualization Laboratory,
  *							University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-----------------------------------------------------------------------------
- * Copyright (c) 2010-2015, Electronic Visualization Laboratory,  
+ * Copyright (c) 2010-2015, Electronic Visualization Laboratory,
  * University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
- * form must reproduce the above copyright notice, this list of conditions and 
- * the following disclaimer in the documentation and/or other materials provided 
- * with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * What's in this file
@@ -40,7 +40,7 @@ using namespace omega;
 NameGenerator sTrackedObjectName("TrackedObject");
 
 ///////////////////////////////////////////////////////////////////////////////
-TrackedObject::TrackedObject(): 
+TrackedObject::TrackedObject():
         Actor(sTrackedObjectName.generate()),
         myTrackableServiceType(Event::ServiceTypeMocap),
         myTrackableSourceId(-1),
@@ -66,7 +66,7 @@ TrackedObject::~TrackedObject()
 ///////////////////////////////////////////////////////////////////////////////
 void TrackedObject::handleEvent(const Event& evt)
 {
-    if(evt.getServiceType() == myTrackableServiceType && 
+    if(evt.getServiceType() == static_cast<enum Service::ServiceType>(myTrackableServiceType) && 
         evt.getSourceId() == myTrackableSourceId)
     {
         myTrackedPosition = evt.getPosition();

--- a/src/omega/WandEmulationService.cpp
+++ b/src/omega/WandEmulationService.cpp
@@ -2,26 +2,26 @@
  * THE OMEGA LIB PROJECT
  *-------------------------------------------------------------------------------------------------
  * Copyright 2010-2015		Electronic Visualization Laboratory, University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-------------------------------------------------------------------------------------------------
  * Copyright (c) 2010-2015, Electronic Visualization Laboratory, University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, are permitted 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this list of conditions 
- * and the following disclaimer. Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in the documentation and/or other 
- * materials provided with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR 
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF 
- * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ * and the following disclaimer. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *************************************************************************************************/
 #include "omega/WandEmulationService.h"
@@ -123,14 +123,14 @@ void WandEmulationService::poll()
 	for(int i = 0; i < numEvts; i++)
 	{
 		Event* evt = getEvent(i);
-		if(evt->getServiceType() == Event::ServiceTypeKeyboard)
+		if(evt->getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypeKeyboard))
 		{
 			eventWasKeyUpDown |= processKey(evt, 'a', Event::ButtonLeft);
 			eventWasKeyUpDown |= processKey(evt, 'd', Event::ButtonRight);
 			eventWasKeyUpDown |= processKey(evt, 'w', Event::ButtonUp);
 			eventWasKeyUpDown |= processKey(evt, 's', Event::ButtonDown);
 
-			// Buttons 1, 2, 3 Are mapped to mouse buttons. Add some 
+			// Buttons 1, 2, 3 Are mapped to mouse buttons. Add some
 			// more buttons using the keyboard
 
 			eventWasKeyUpDown |= processKey(evt, '1', Event::Button3);
@@ -139,8 +139,8 @@ void WandEmulationService::poll()
 			eventWasKeyUpDown |= processKey(evt, '4', Event::Button6);
 			evt->setProcessed();
 		}
-		
-		if(evt->getServiceType() == Event::ServiceTypePointer)
+
+		if(evt->getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypePointer))
 		{
 			eventWasKeyUpDown |= processPointer(evt);
 			evt->setProcessed();

--- a/src/omegaToolkit/UiScriptCommand.cpp
+++ b/src/omegaToolkit/UiScriptCommand.cpp
@@ -60,11 +60,11 @@ UiScriptCommand::UiScriptCommand(const String& command):
 ///////////////////////////////////////////////////////////////////////////////
 void UiScriptCommand::handleEvent(const Event& evt)
 {
-    if(myUiEventsOnly && evt.getServiceType() != Event::ServiceTypeUi) return;
-    
+    if (myUiEventsOnly && evt.getServiceType() != static_cast<enum Service::ServiceType>(Event::ServiceTypeUi)) { return; }
+
     evt.setProcessed();
 
-    if(myInterpreter != NULL)
+    if (myInterpreter != NULL)
     {
         if(evt.getType() == Event::Toggle)
         {
@@ -101,4 +101,3 @@ void UiScriptCommand::handleEvent(const Event& evt)
         }
     }
 }
-

--- a/src/omegaToolkit/ui/Button.cpp
+++ b/src/omegaToolkit/ui/Button.cpp
@@ -1,32 +1,32 @@
 /******************************************************************************
  * THE OMEGA LIB PROJECT
  *-----------------------------------------------------------------------------
- * Copyright 2010-2015		Electronic Visualization Laboratory, 
+ * Copyright 2010-2015		Electronic Visualization Laboratory,
  *							University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-----------------------------------------------------------------------------
- * Copyright (c) 2010-2015, Electronic Visualization Laboratory,  
+ * Copyright (c) 2010-2015, Electronic Visualization Laboratory,
  * University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
- * form must reproduce the above copyright notice, this list of conditions and 
- * the following disclaimer in the documentation and/or other materials provided 
- * with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * What's in this file:
@@ -122,7 +122,7 @@ void Button::handleEvent(const Event& evt)
 {
 	if(isPointerInteractionEnabled())
 	{
-		if(evt.getServiceType() == Event::ServiceTypePointer)// || evt.getServiceType() == Event::ServiceTypeWand)
+		if(evt.getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypePointer))// || evt.getServiceType() == Event::ServiceTypeWand)
 		{
 			Vector2f point  = Vector2f(evt.getPosition().x(), evt.getPosition().y());
 			point = transformPoint(point);

--- a/src/omegaToolkit/ui/Container.cpp
+++ b/src/omegaToolkit/ui/Container.cpp
@@ -1,32 +1,32 @@
 /******************************************************************************
  * THE OMEGA LIB PROJECT
  *-----------------------------------------------------------------------------
- * Copyright 2010-2015		Electronic Visualization Laboratory, 
+ * Copyright 2010-2015		Electronic Visualization Laboratory,
  *							University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-----------------------------------------------------------------------------
- * Copyright (c) 2010-2015, Electronic Visualization Laboratory,  
+ * Copyright (c) 2010-2015, Electronic Visualization Laboratory,
  * University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
- * form must reproduce the above copyright notice, this list of conditions and 
- * the following disclaimer in the documentation and/or other materials provided 
- * with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * What's in this file:
@@ -158,7 +158,7 @@ void Container::addChild(Widget* child)
 void Container::removeChild(Widget* child)
 {
     requestLayoutRefresh();
-    // Do not remove tis child now. Just register it as a child to remove. 
+    // Do not remove tis child now. Just register it as a child to remove.
     // We do this since this method may be called as part of a child update:
     // removing the child from the list directly would break iteration.
     myChildrenToRemove.push_back(child);
@@ -243,7 +243,7 @@ void Container::autosize()
     int maxheight = 0;
     foreach(Widget* w, myChildren)
     {
-        // If widget has size anchoring enabled, its size depends on this 
+        // If widget has size anchoring enabled, its size depends on this
         // container size. Do not keep into account when auto-sizing this container
         // to avoid a circular dependency in size resolution.
         if(!w->isSizeAnchorEnabled())
@@ -292,7 +292,7 @@ void Container::autosize()
         height = 0;
         foreach(Widget* w, myChildren)
         {
-            // If widget has size anchoring enabled, its size depends on this 
+            // If widget has size anchoring enabled, its size depends on this
             // container size. Do not keep into account when auto-sizing this container
             // to avoid a circular dependency in size resolution.
             if(!w->isSizeAnchorEnabled())
@@ -439,7 +439,7 @@ void Container::resetChildrenSize(Orientation orientation)
 {
     // Initialize widget width to 0
     foreach(Widget* w, myChildren)
-    { 
+    {
         w->mySize[orientation] = 0;
     }
 }
@@ -626,7 +626,7 @@ bool Container::rayToPointerEvent(const Event& inEvt, Event& outEvt)
 
         // Turn the intersection point from world coordinates to pixel, ui coordinates.
         intersection = pos - intersection;
-        
+
         Vector3f widthVector = -my3dSettings.up.cross(my3dSettings.normal);
         Vector3f heightVector = -my3dSettings.up;
 
@@ -662,9 +662,9 @@ bool Container::isEventInside(const Event& evt)
         Event newEvt;
         return rayToPointerEvent(evt, newEvt);
     }
-    
+
     // Intersection with 2D containers
-    if(evt.getServiceType() == Event::ServiceTypePointer)
+    if(evt.getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypePointer))
     {
         Vector2f pos2d = Vector2f(evt.getPosition().x(), evt.getPosition().y());
         return hitTest(pos2d);
@@ -679,7 +679,7 @@ void Container::handleEvent(const Event& evt)
     // Only handle events if the container is visible.
     if(isVisible() && isEnabled())
     {
-        // Container is displayed in 3d mode. Convert pointer rays and wand rays into 
+        // Container is displayed in 3d mode. Convert pointer rays and wand rays into
         // standard pointer events.
         if(my3dSettings.enable3d && isPointerInteractionEnabled())
         {
@@ -706,12 +706,12 @@ void Container::handleEvent(const Event& evt)
                         if(w->getLayer() == layer)
                         {
                             w->handleEvent(evt);
-                            // If the event has been marked as processed, skip the 
+                            // If the event has been marked as processed, skip the
                             // rest of this container children.
                             if(evt.isProcessed()) break;
                         }
                     }
-                    // If the event has been marked as processed, skip the 
+                    // If the event has been marked as processed, skip the
                     // rest of this container children.
                     if(evt.isProcessed()) break;
                 }
@@ -746,9 +746,9 @@ void Container::activate()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-bool Container::isPixelOutputEnabled() 
-{ 
-    return myPixelOutputEnabled; 
+bool Container::isPixelOutputEnabled()
+{
+    return myPixelOutputEnabled;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -784,9 +784,9 @@ void ContainerRenderable::drawChildren(const DrawContext& context, bool containe
             if(w->getLayer() == layer)
             {
                 Renderable* childRenderable;
-                if(containerOnly) childRenderable = dynamic_cast<ContainerRenderable*>(w->getRenderable(getClient())); 
-                else childRenderable = w->getRenderable(getClient()); 
-                if(childRenderable != NULL) 
+                if(containerOnly) childRenderable = dynamic_cast<ContainerRenderable*>(w->getRenderable(getClient()));
+                else childRenderable = w->getRenderable(getClient());
+                if(childRenderable != NULL)
                 {
                     childRenderable->draw(context);
                 }
@@ -886,7 +886,7 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
     {
         if(myOwner->get3dSettings().enable3d)
         {
-            if(myRenderTarget == NULL || 
+            if(myRenderTarget == NULL ||
                 myTexture->getWidth() != myOwner->getWidth() ||
                 myTexture->getHeight() != myOwner->getHeight())
             {
@@ -900,7 +900,7 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
         else if(myOwner->isPixelOutputEnabled())
         {
             PixelData* pixels = myOwner->getPixels();
-            if(myRenderTarget == NULL || 
+            if(myRenderTarget == NULL ||
                 pixels->getWidth() != myOwner->getWidth() ||
                 pixels->getHeight() != myOwner->getHeight())
             {
@@ -915,7 +915,7 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
 
         glPushAttrib(GL_VIEWPORT_BIT);
         glViewport(0, 0, myOwner->getWidth(), myOwner->getHeight());
-                
+
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
         glLoadIdentity();
@@ -926,7 +926,7 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
         glMatrixMode(GL_MODELVIEW);
         glPushMatrix();
         glLoadIdentity();
-        
+
         //glScalef(0.05f, 0.05f, 1);
         //glTranslatef(0, -SystemManager::instance()->getDisplaySystem()->getDisplayConfig().getCanvasRect().size().y(), 0);
 
@@ -934,7 +934,7 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
 
         pushDrawAttributes();
 
-        if(myOwner->isPixelOutputEnabled()) 
+        if(myOwner->isPixelOutputEnabled())
         {
             glClearColor(0, 0, 0, 0);
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -943,7 +943,7 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
     else
     {
         preDraw();
-        
+
         // start stencil buffer for clipping
         if(myOwner->isClippingEnabled())
         {
@@ -960,7 +960,7 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
             glDepthMask(GL_FALSE);
             glStencilFunc(GL_NEVER, 0x1, 0x1);
             glStencilOp(GL_REPLACE, GL_KEEP, GL_KEEP);
- 
+
             glClear(GL_STENCIL_BUFFER_BIT);
             glColor4f(1.0, 1.0, 1.0, 1.0);
             glBegin(GL_QUADS);
@@ -969,11 +969,11 @@ void ContainerRenderable::beginDraw(const DrawContext& context)
                 glVertex2f(width, height);
                 glVertex2f(0.0, height);
             glEnd();
-        
+
             glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
             glDepthMask(GL_TRUE);
             glStencilMask(0x0);
-        
+
             glStencilFunc(GL_EQUAL, 0x1, 0x1);
         }
     }
@@ -1022,16 +1022,16 @@ void ContainerRenderable::draw(const DrawContext& context)
             }
             else
             {
-                // The 'true' 2nd argument makes drawChildren iterate only 
-                // through container renderables. We are doing this to give all 
+                // The 'true' 2nd argument makes drawChildren iterate only
+                // through container renderables. We are doing this to give all
                 // containers that have 3D mode enabled a chance to render.
                 drawChildren(context, true);
             }
         }
         else
         {
-            // If culling is enabled, we are not drawing a 3D container and 
-            // the bounds of this container are out of the viewport, return 
+            // If culling is enabled, we are not drawing a 3D container and
+            // the bounds of this container are out of the viewport, return
             // immediately.
             // NOTE: We do not cull rotated widgets, since we would need to readjust
             // the math here for that to work. And we are too lazy now for that.
@@ -1040,11 +1040,11 @@ void ContainerRenderable::draw(const DrawContext& context)
             {
                 //const Vector2f& pos = myOwner->getPosition();
                 const Vector2f& size = myOwner->getSize() * myOwner->getScale();
-                
+
                 // Convert the tile offset in widget-space coordinates
                 Vector2f tp(context.tile->activeCanvasRect.min[0], context.tile->activeCanvasRect.min[1]);
                 const Vector2i tileOffs = myOwner->transformPoint(tp).cast<int>();
-                
+
                 // See if the two widget-space rectangles (the tile and the widget)
                 // intersect
                 Rect myrect(Vector2i::Zero(), myOwner->getSize().cast<int>() * myOwner->getScale());
@@ -1070,5 +1070,3 @@ void ContainerRenderable::draw(const DrawContext& context)
         }
     }
 }
-
-

--- a/src/omegaToolkit/ui/Menu.cpp
+++ b/src/omegaToolkit/ui/Menu.cpp
@@ -1,32 +1,32 @@
 /******************************************************************************
  * THE OMEGA LIB PROJECT
  *-----------------------------------------------------------------------------
- * Copyright 2010-2015		Electronic Visualization Laboratory, 
+ * Copyright 2010-2015		Electronic Visualization Laboratory,
  *							University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-----------------------------------------------------------------------------
- * Copyright (c) 2010-2015, Electronic Visualization Laboratory,  
+ * Copyright (c) 2010-2015, Electronic Visualization Laboratory,
  * University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
- * form must reproduce the above copyright notice, this list of conditions and 
- * the following disclaimer in the documentation and/or other materials provided 
- * with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * What's in this file
@@ -102,9 +102,9 @@ MenuItem::MenuItem(Type type, Menu* owner):
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void MenuItem::setText(const String& value) 
-{ 
-    myText = value; 
+void MenuItem::setText(const String& value)
+{
+    myText = value;
     switch(myType)
     {
     case MenuItem::Button:
@@ -120,9 +120,9 @@ void MenuItem::setText(const String& value)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void MenuItem::setDescription(const String& value) 
-{ 
-    myDescription = value; 
+void MenuItem::setDescription(const String& value)
+{
+    myDescription = value;
     switch(myType)
     {
     case MenuItem::Button:
@@ -131,7 +131,7 @@ void MenuItem::setDescription(const String& value)
         break;
     }
 }
-        
+
 ///////////////////////////////////////////////////////////////////////////////
 void MenuItem::setImage(PixelData* image)
 {
@@ -186,9 +186,9 @@ const String& MenuItem::getCommand()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void MenuItem::setListener(IMenuItemListener* value) 
+void MenuItem::setListener(IMenuItemListener* value)
 {
-    myListener = value; 
+    myListener = value;
     if(myListener != NULL)
     {
         myWidget->setUIEventHandler(this);
@@ -209,7 +209,7 @@ void MenuItem::handleEvent(const Event& evt)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-Menu::Menu(const String& name, MenuManager* manager): 
+Menu::Menu(const String& name, MenuManager* manager):
     myName(name),
     myManager(manager),
     myActiveSubMenu(NULL),
@@ -305,7 +305,7 @@ Menu* Menu::addSubMenu(const String& label)
 void Menu::update(const UpdateContext& context)
 {
     float speed = context.dt * 10;
-    if(speed > 1.0f) speed = 1.0f; 
+    if(speed > 1.0f) speed = 1.0f;
 
     ui::Container3dSettings& c3ds = myContainer->get3dSettings();
     c3ds.enable3d = my3dSettings.enable3d;
@@ -478,7 +478,7 @@ void Menu::hide()
         // Play a sound based on menu's position
         Ref<SoundInstance> hideSound = new SoundInstance(myManager->getHideMenuSound());
         hideSound->setLocalPosition( my3dSettings.position );
-        
+
         if( firstHide )
             firstHide = false;
         else
@@ -510,7 +510,7 @@ void Menu::placeOnWand(const Event& evt)
                 // This is a bit of trickery: If the event is a pointer event we use the orientation of the node
                 // to determine the menu orientation.
                 // If the event is a Wand event (with 6DOF tracking) we use the actual wand orientation.
-                if(evt.getServiceType() == Event::ServiceTypeWand)
+                if(evt.getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypeWand))
                 {
                     dir = evt.getOrientation() * -Vector3f::UnitZ();
                 }
@@ -548,7 +548,7 @@ void Menu::placeOnWand(const Event& evt)
     else
     {
         // Place 2D menu
-        if(evt.getServiceType() == Event::ServiceTypePointer)
+        if(evt.getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypePointer))
         {
             myContainer->setPosition(
                 Vector2f(evt.getPosition()[0], evt.getPosition()[1]));
@@ -568,4 +568,3 @@ bool Menu::isVisible()
 {
     return myVisible;
 }
-

--- a/src/omegaToolkit/ui/TextBox.cpp
+++ b/src/omegaToolkit/ui/TextBox.cpp
@@ -1,32 +1,32 @@
 /******************************************************************************
  * THE OMEGA LIB PROJECT
  *-----------------------------------------------------------------------------
- * Copyright 2010-2015		Electronic Visualization Laboratory, 
+ * Copyright 2010-2015		Electronic Visualization Laboratory,
  *							University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-----------------------------------------------------------------------------
- * Copyright (c) 2010-2015, Electronic Visualization Laboratory,  
+ * Copyright (c) 2010-2015, Electronic Visualization Laboratory,
  * University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
- * form must reproduce the above copyright notice, this list of conditions and 
- * the following disclaimer in the documentation and/or other materials provided 
- * with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * What's in this file:
@@ -118,7 +118,7 @@ void TextBox::handleEvent(const Event& evt)
     Label::handleEvent(evt);
     if(isActive())
     {
-        if(evt.getServiceType() == Event::ServiceTypeKeyboard && 
+        if(evt.getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypeKeyboard) && 
             evt.getType() == Event::Down)
         {
             // Process special keys
@@ -169,4 +169,3 @@ void TextBox::update(const omega::UpdateContext& context)
 {
     Label::update(context);
 }
-

--- a/src/omegaToolkit/ui/Widget.cpp
+++ b/src/omegaToolkit/ui/Widget.cpp
@@ -1,32 +1,32 @@
 /******************************************************************************
  * THE OMEGA LIB PROJECT
  *-----------------------------------------------------------------------------
- * Copyright 2010-2015		Electronic Visualization Laboratory, 
+ * Copyright 2010-2015		Electronic Visualization Laboratory,
  *							University of Illinois at Chicago
- * Authors:										
+ * Authors:
  *  Alessandro Febretti		febret@gmail.com
  *-----------------------------------------------------------------------------
- * Copyright (c) 2010-2015, Electronic Visualization Laboratory,  
+ * Copyright (c) 2010-2015, Electronic Visualization Laboratory,
  * University of Illinois at Chicago
  * All rights reserved.
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this 
- * list of conditions and the following disclaimer. Redistributions in binary 
- * form must reproduce the above copyright notice, this list of conditions and 
- * the following disclaimer in the documentation and/or other materials provided 
- * with the distribution. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR 
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * What's in this file:
@@ -133,7 +133,7 @@ Widget::Widget(Engine* server):
 
     myFillEnabled = false;
     memset(myBorders, 0, sizeof(BorderStyle) * 4);
-    
+
     {
         AutoLock autolock(mysWidgetsMutex);
         mysWidgets[myId] = this;
@@ -162,11 +162,11 @@ WidgetFactory* Widget::getFactory()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-float Widget::getAlpha() 
-{ 
+float Widget::getAlpha()
+{
     // Alpha is modulated by alpha from container of this widget.
     if(myContainer == NULL) return myAlpha;
-    return myAlpha * myContainer->getAlpha(); 
+    return myAlpha * myContainer->getAlpha();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -225,7 +225,7 @@ void Widget::setActive(bool value)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void Widget::update(const omega::UpdateContext& context) 
+void Widget::update(const omega::UpdateContext& context)
 {
     if(!myInitialized)
     {
@@ -244,7 +244,7 @@ void Widget::update(const omega::UpdateContext& context)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void Widget::handleEvent(const Event& evt) 
+void Widget::handleEvent(const Event& evt)
 {
     // If widget is disabled there is nothing to do here..
     if(!myEnabled) return;
@@ -299,12 +299,12 @@ void Widget::handleEvent(const Event& evt)
             // after local event handling in ConfigImpl, lines 259-265
             // dispathUIEvent marks events as local, which prevents events from
             // broadcasting.
-            // If we want to re-enable the following block of code, we need to 
+            // If we want to re-enable the following block of code, we need to
             // do it on an opt-in basis (only for widgets that want it), and we
             // probably need to copy the event to a separate one, so the original
             // does not get makred as local and still gets distributed.
             // -----------------------------------------------------------------
-            // If gamepad interaction is enabled and event is a down or up event, 
+            // If gamepad interaction is enabled and event is a down or up event,
             // (and not one of the navigation buttons, dispatch it to possible listeners)
             // NOTE: we do not dispatch Move or Update events here to avoid clogging the listeners with events they do not care about
             // In the future, we may add an option to selectively enable dispatch of those events.
@@ -316,7 +316,7 @@ void Widget::handleEvent(const Event& evt)
         }
     }
 
-    if(isPointerInteractionEnabled() && evt.getServiceType() == Event::ServiceTypePointer)
+    if(isPointerInteractionEnabled() && evt.getServiceType() == static_cast<enum Service::ServiceType>(Event::ServiceTypePointer))
     {
         Vector2f pos2d = Vector2f(evt.getPosition().x(), evt.getPosition().y());
         // NOTE: Drag move and end does not depend on the pointer actually being on
@@ -407,10 +407,10 @@ void Widget::clearSizeConstaints()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void Widget::setContainer(Container* value) 
-{ 
+void Widget::setContainer(Container* value)
+{
     //oassert(value && value->getManager() == myManager);
-    myContainer = value; 
+    myContainer = value;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -472,7 +472,7 @@ Vector2f Widget::transformPoint(const Vector2f& point)
 ///////////////////////////////////////////////////////////////////////////////
 void Widget::dispatchUIEvent(const Event& evt)
 {
-    if(myEventHandler != NULL) 
+    if(myEventHandler != NULL)
     {
         // If the local events option is set, mark ui events as local before dispatching them to
         // the event listener. Local events do not get broadcast to other nodes in clustered systems.
@@ -482,7 +482,7 @@ void Widget::dispatchUIEvent(const Event& evt)
         }
         myEventHandler->handleEvent(evt);
     }
-    else if(myContainer != NULL) 
+    else if(myContainer != NULL)
     {
             myContainer->dispatchUIEvent(evt);
     }
@@ -507,8 +507,8 @@ void Widget::playMenuScrollSound()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void Widget::requestLayoutRefresh() 
-{ 
+void Widget::requestLayoutRefresh()
+{
     if(!myNeedLayoutRefresh)
     {
         UiModule::instance()->queueWidgetForLayoutRefresh(this);
@@ -522,15 +522,15 @@ void Widget::requestLayoutRefresh()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-bool Widget::needLayoutRefresh() 
-{ 
-    return myNeedLayoutRefresh; 
+bool Widget::needLayoutRefresh()
+{
+    return myNeedLayoutRefresh;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void Widget::layout()
-{ 
-    myNeedLayoutRefresh = false; 
+{
+    myNeedLayoutRefresh = false;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -561,7 +561,7 @@ void Widget::updateSize()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void Widget::setActualSize(int value, Orientation orientation, bool force) 
+void Widget::setActualSize(int value, Orientation orientation, bool force)
 {
     if(mySize[orientation] != value)
     {
@@ -571,7 +571,7 @@ void Widget::setActualSize(int value, Orientation orientation, bool force)
             if(value < myMinimumSize[orientation]) value = myMinimumSize[orientation];
             if(value > myMaximumSize[orientation]) value = myMaximumSize[orientation];
         }
-        mySize[orientation] = value; 
+        mySize[orientation] = value;
     }
 }
 
@@ -766,7 +766,7 @@ void WidgetRenderable::postDraw()
     if(myOwner->myPostDrawCallback != NULL)
     {
         oassert(myCurrentContext != NULL);
-        
+
         if(myCurrentContext->task == DrawContext::OverlayDrawTask &&
             myCurrentContext->eye == DrawContext::EyeCyclop)
         {
@@ -839,7 +839,7 @@ void WidgetRenderable::draw(const DrawContext& context)
     {
         if(myOwner->isStereo())
         {
-            if(context.eye != DrawContext::EyeCyclop) 
+            if(context.eye != DrawContext::EyeCyclop)
             {
                 preDraw();
                 drawContent(context);
@@ -848,7 +848,7 @@ void WidgetRenderable::draw(const DrawContext& context)
         }
         else
         {
-            if(context.eye == DrawContext::EyeCyclop) 
+            if(context.eye == DrawContext::EyeCyclop)
             {
                 preDraw();
                 drawContent(context);
@@ -904,4 +904,3 @@ void WidgetRenderable::drawContent(const DrawContext& context)
     }
     glLineWidth(1);
 }
-


### PR DESCRIPTION
In omega/ImageUtils.cpp, ImageUtils::getPreallocatedBlock returned a false to a void*, which was throwing errors. It now returns a NULL as 'nullptr' is not avaliable.

In several other areas, an enum in EventBase to a returned enum of type Service::ServiceType were being compared. This originates from the two enums using equivalent values but being of different types in omicron's source. This was fixed with a static_cast to the EventBase side.